### PR TITLE
add gradle include group

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -5,7 +5,12 @@ android {
 		google()
 		jcenter()
 		maven {
-			url "https://github.com/jitsi/jitsi-maven-repository/raw/master/releases"
+		    url "https://github.com/jitsi/jitsi-maven-repository/raw/master/releases"
+			content {
+                		includeGroup("org.jitsi.react")
+                		includeGroup("org.webkit")
+                		includeGroupByRegex("com.facebook.*")
+            		}
 		}
 	}
 


### PR DESCRIPTION
this reduces the risk of issues coming up with this plugin coexisting with another plugin that uses `maven { url "https://jitpack.io" }` example https://github.com/AlexMiniApps/cordova-plugin-video-editor . This only reduces the risk. the other plugin needs to also use includeGroup or error will be something like 

```
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Could not resolve org.jitsi.react:jitsi-meet-sdk:3.+.
     Required by:
         project :app
      > Failed to list versions for org.jitsi.react:jitsi-meet-sdk.
         > Unable to load Maven meta-data from https://jitpack.io/org/jitsi/react/jitsi-meet-sdk/maven-metadata.xml.
            > Could not GET 'https://jitpack.io/org/jitsi/react/jitsi-meet-sdk/maven-metadata.xml'. Received status code 521 from server:
```